### PR TITLE
Use combinators instead of ifs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,8 @@ extern crate chrono;
 
 use self::sonnerie_api::{NaiveDateTime,Column,Direction};
 
+use client::chrono::naive::NaiveDate;
+
 use std::net::TcpStream;
 
 use std::process::{Child,Stdio,Command};
@@ -529,48 +531,26 @@ fn command<'client>(
 
 fn run_pager() -> Child
 {
-	if let Ok(p) = ::std::env::var("PAGER")
-	{
-		let child = Command::new(p)
-			.stdin(Stdio::piped())
-			.spawn();
-		if let Ok(c) = child
-			{ return c; }
-	}
-	let child = Command::new("less")
-		.arg("-FX")
-		.stdin(Stdio::piped())
-		.spawn();
-	if let Ok(c) = child
-		{ return c; }
-	let child = Command::new("more")
-		.stdin(Stdio::piped())
-		.spawn();
-	if let Ok(c) = child
-		{ return c; }
-	let child = Command::new("cat")
-		.stdin(Stdio::piped())
-		.spawn();
-	if let Ok(c) = child
-		{ return c; }
-
-	panic!("failed to run any kind of pager, even cat");
+        ::std::env::var("PAGER")
+                .ok()
+                .and_then(|p| Command::new(p).stdin(Stdio::piped()).spawn().ok())
+                .or_else(|| {
+                        Command::new("less")
+                                .arg("-FX")
+                                .stdin(Stdio::piped())
+                                .spawn()
+                                .ok()
+                })
+                .or_else(|| Command::new("more").stdin(Stdio::piped()).spawn().ok())
+                .or_else(|| Command::new("cat").stdin(Stdio::piped()).spawn().ok())
+                .expect("failed to run any kind of pager, even cat")
 }
 
 fn parse_human_times(t: &str)
 	-> Option<NaiveDateTime>
 {
-	if let Ok(a) = NaiveDateTime::parse_from_str(
-		t, "%Y-%m-%d %H:%M:%S%.f"
-	)
-		{ return Some(a); };
-	if let Ok(a) = NaiveDateTime::parse_from_str(
-		t, "%Y-%m-%dT%H:%M:%S%.f"
-	)
-		{ return Some(a); };
-	if let Ok(a) = NaiveDateTime::parse_from_str(
-		&format!("{} 00:00:00", t), "%Y-%m-%d %H:%M:%S"
-	)
-		{ return Some(a); };
-	None
+        NaiveDateTime::parse_from_str(t, "%Y-%m-%d %H:%M:%S%.f")
+                .or_else(|_| NaiveDateTime::parse_from_str(t, "%Y-%m-%dT%H:%M:%S%.f"))
+                .or_else(|_| NaiveDate::parse_from_str(t, "%Y-%m-%d").map(|d| d.and_hms(0, 0, 0)))
+                .ok()
 }


### PR DESCRIPTION
~~This PR formats all the code using `cargo fmt` and makes simple, syntactical changes suggested by `cargo clippy`.~~

I was not able to run the tests either before or after making changes. All of the changes are purely syntactical so they shouldn't break anyways.

There were some clippy lints which I did not follow because they would alter the public api of the library;

```
warning: methods called `as_*` usually take self by reference or self by mutable reference; consider choosing a less ambiguous name
   --> src/metadata.rs:127:32
    |
127 |     pub fn as_read_transaction(self) -> Transaction<'static> {
    |                                ^^^^
    |
    = note: #[warn(clippy::wrong_self_convention)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#wrong_self_convention

warning: methods called `as_*` usually take self by reference or self by mutable reference; consider choosing a less ambiguous name
   --> src/metadata.rs:139:9
    |
139 |         mut self,
    |         ^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#wrong_self_convention

warning: the function has a cyclomatic complexity of 36
   --> src/service.rs:67:5
    |
67  | /     fn one_command(&mut self, cmd: &str, remainder: &str) -> Result<(), String> {
68  | |         let writer = &mut self.writer;
69  | |         let db = &mut self.db;
70  | |         let cache_last_series_id = &mut self.cache_last_series_id;
...   |
414 | |         Ok(())
415 | |     }
    | |_____^
    |
    = note: #[warn(clippy::cyclomatic_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cyclomatic_complexity

warning: this argument is passed by value, but not consumed in the function body
   --> src/service.rs:427:30
    |
427 | pub fn service_tcp(listener: TcpListener, mut db: Db) {
    |                              ^^^^^^^^^^^ help: consider taking a reference instead: `&TcpListener`
    |
    = note: #[warn(clippy::needless_pass_by_value)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#needless_pass_by_value

warning: this argument is passed by value, but not consumed in the function body
   --> src/service.rs:454:31
    |
454 | pub fn service_unix(listener: UnixListener, mut db: Db) {
    |                               ^^^^^^^^^^^^ help: consider taking a reference instead: `&UnixListener`
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#needless_pass_by_value

warning: this argument is passed by value, but not consumed in the function body
  --> src/wal.rs:51:13
   |
51 |     cursor: CursorMut<'a, A>,
   |             ^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&CursorMut<'a, A>`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#needless_pass_by_value
```
