### PR TITLE
Add a better support for empty segment

### DIFF
--- a/src/segment_reader.rs
+++ b/src/segment_reader.rs
@@ -28,6 +28,10 @@ impl SegmentReader {
 			let mut buffer = vec![];
 			decode_into_with_unescaping(&mut buffer, segment.payload);
 
+			if buffer.is_empty() {
+				return Ok(Left(reader));
+			}
+
 			// bytes 0 .. 4 are the key length
 			// bytes 4 .. 8 are the format string length
 			// bytes 8 .. 12 are the payload length

--- a/src/write.rs
+++ b/src/write.rs
@@ -180,7 +180,9 @@ impl<W: Write + Send> Writer<W> {
 				}
 			}
 
-			if self.current_segment_data.len() + self.current_key_data.len() >= SEGMENT_SIZE_GOAL {
+			if self.current_segment_data.len() + self.current_key_data.len() >= SEGMENT_SIZE_GOAL
+				&& !self.current_segment_data.is_empty()
+			{
 				// the segment is full, flush it
 				self.store_current_segment()?;
 				self.first_segment_key.replace_range(.., key);
@@ -345,6 +347,7 @@ fn worker_thread<W: Write + Send>(
 			}
 			wrote_size = bc.count().try_into().map_err(ee)?;
 		}
+
 		if header.last_key == header.first_key {
 			wl.stored_size_last_key += wrote_size;
 		} else {


### PR DESCRIPTION
Could fix #18.

Please, review this in detail as I am absolutely not sure it is the right way to fix this. I would say that it is maybe more related to the segment writer that should not generate empty ones.

I have added a fix to the `worker_thread` function to be sure that it doesn't try to write a segment that has an empty `current_segment_data`. But I am not sure what the `current_key_data`, what it contains and why it is larger than `SEGMENT_SIZE_GOAL`, and why it is so big?

By using this fix you'll be able to output the entries in the tx file from #18 (all of them?).