### PR TITLE
Feature gate the test `parallel_split1` to fix test compilation

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -647,7 +647,7 @@ fn parallel_split1() {
 
 	let w = crate::Wildcard::new("%");
 
-	let s = db.get_filter_keys(&w).into_par_iter().count();
+	let s = db.get_filter(&w).into_par_iter().count();
 	assert_eq!(s, 999);
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -639,6 +639,7 @@ fn keys_split() {
 }
 
 #[test]
+#[cfg(feature = "by-key")]
 fn parallel_split1() {
 	let (_t, db) = make_big_database(1000);
 
@@ -647,7 +648,7 @@ fn parallel_split1() {
 
 	let w = crate::Wildcard::new("%");
 
-	let s = db.get_filter(&w).into_par_iter().count();
+	let s = db.get_filter_keys(&w).into_par_iter().count();
 	assert_eq!(s, 999);
 }
 


### PR DESCRIPTION
Apparently the tests failed to compile due to:
```
error[E0599]: no method named `get_filter_keys` found for struct `database_reader::DatabaseReader` in the current scope
   --> src/tests.rs:650:13
    |
650 |     let s = db.get_filter_keys(&w).into_par_iter().count();
    |                ^^^^^^^^^^^^^^^ help: there is a method with a similar name: `get_filter`
    |
   ::: src/database_reader.rs:25:1
    |
25  | pub struct DatabaseReader {
    | ------------------------- method `get_filter_keys` not found for this struct
```
So this should fix it, because the `get_filter_keys` is behind the `by-key` feature flag.

PS.: A CI workflow would benefit the project massively :)
