### PR TITLE
resolve all warnings

### DIFF
--- a/src/create_tx.rs
+++ b/src/create_tx.rs
@@ -73,9 +73,14 @@ impl CreateTx {
 		key: &str,
 		timestamp: chrono::NaiveDateTime,
 		values: impl crate::RecordBuilder,
-	) -> std::result::Result<(), crate::write::WriteFailure> {
-		self.writer
-			.add_record(key, timestamp.timestamp_nanos() as crate::Timestamp, values)
+	) -> std::result::Result<(), crate::WriteFailure> {
+		self.writer.add_record(
+			key,
+			timestamp
+				.timestamp_nanos_opt()
+				.ok_or(crate::WriteFailure::UnableToParseTimestamp)? as crate::Timestamp,
+			values,
+		)
 	}
 
 	/// Add a record with the given key, format, and payload.

--- a/src/formatted.rs
+++ b/src/formatted.rs
@@ -39,7 +39,9 @@ pub fn add_from_stream<R: std::io::BufRead>(
 		if let Some(f) = timestamp_format.as_ref() {
 			let n = chrono::NaiveDateTime::parse_from_str(&timestamp, f)
 				.expect("parsing timestamp according to format");
-			ts = n.timestamp_nanos() as Timestamp;
+			ts = n
+				.timestamp_nanos_opt()
+				.ok_or(crate::WriteFailure::UnableToParseTimestamp)? as Timestamp;
 		} else {
 			ts = timestamp.parse().expect("parsing timestamp");
 		}
@@ -79,7 +81,9 @@ pub fn add_from_stream_with_fmt<R: std::io::BufRead>(
 		if let Some(f) = timestamp_format.as_ref() {
 			let n = chrono::NaiveDateTime::parse_from_str(&timestamp, f)
 				.expect("parsing timestamp according to format");
-			ts = n.timestamp_nanos() as Timestamp;
+			ts = n
+				.timestamp_nanos_opt()
+				.ok_or(crate::WriteFailure::UnableToParseTimestamp)? as Timestamp;
 		} else {
 			ts = timestamp.parse().expect("parsing timestamp");
 		}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -647,7 +647,7 @@ fn parallel_split1() {
 
 	let w = crate::Wildcard::new("%");
 
-	let s = db.get_filter_keys(&w).into_par_iter().count();
+	let s = db.get_filter(&w).into_par_iter().count();
 	assert_eq!(s, 999);
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -639,6 +639,7 @@ fn keys_split() {
 }
 
 #[test]
+#[cfg(feature = "by-key")]
 fn parallel_split1() {
 	let (_t, db) = make_big_database(1000);
 
@@ -647,7 +648,7 @@ fn parallel_split1() {
 
 	let w = crate::Wildcard::new("%");
 
-	let s = db.get_filter(&w).into_par_iter().count();
+	let s = db.get_filter_keys(&w).into_par_iter().count();
 	assert_eq!(s, 999);
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1102,9 +1102,15 @@ fn configurable_delete_test(
 		tx.delete(
 			dbg!(begin_key.as_deref().unwrap_or("")),
 			dbg!(end_key.as_deref().unwrap_or("")),
-			dbg!(begin_time.map(|t| t.timestamp_nanos() as u64).unwrap_or(0)),
+			dbg!(begin_time
+				.map(|t| t
+					.timestamp_nanos_opt()
+					.expect("This is a test and must work; qed") as u64)
+				.unwrap_or(0)),
 			dbg!(end_time
-				.map(|t| t.timestamp_nanos() as u64)
+				.map(|t| t
+					.timestamp_nanos_opt()
+					.expect("This is a test and must work; qed") as u64)
 				.unwrap_or(u64::MAX)),
 			dbg!(wildcard_str),
 		)

--- a/src/write.rs
+++ b/src/write.rs
@@ -73,6 +73,9 @@ pub enum WriteFailure {
 	/// An IO error from the OS
 	#[error("io error")]
 	IOError(#[from] std::io::Error),
+	/// The timestamp was not in the expected format
+	#[error("Unable to parse the timestamp")]
+	UnableToParseTimestamp,
 }
 
 impl<W: Write + Send> Writer<W> {


### PR DESCRIPTION
## Changes:
- Do not use the deprecated `timestamp_nanos` anymore, but instead `timestamp_nanos_opt`.
- Explicitly handle the optional values from the new method.

Please double check that the `expect`'s are indeed valid in the context in which they appear. 