### PR TITLE
Switch to using std::ascii::escape_default

### DIFF
--- a/escape_string/src/lib.rs
+++ b/escape_string/src/lib.rs
@@ -150,24 +150,12 @@ pub fn escape<'a>(text: &'a str) -> Cow<'a, str> {
 	let mut owned = None;
 
 	for pos in 0..bytes.len() {
-		let special = match bytes[pos] {
-			0x07 => Some(b'a'),
-			0x08 => Some(b'b'),
-			b'\t' => Some(b't'),
-			b'\n' => Some(b'n'),
-			0x0b => Some(b'v'),
-			0x0c => Some(b'f'),
-			b'\r' => Some(b'r'),
-			b' ' => Some(b' '),
-			b'\\' => Some(b'\\'),
-			_ => None,
-		};
-		if let Some(s) = special {
+		let special: Box<[u8]> = std::ascii::escape_default(bytes[pos]).collect();
+		if special.len() > 1 {
 			if owned.is_none() {
 				owned = Some(bytes[0..pos].to_owned());
 			}
-			owned.as_mut().unwrap().push(b'\\');
-			owned.as_mut().unwrap().push(s);
+			owned.as_mut().unwrap().push(special);
 		} else if let Some(owned) = owned.as_mut() {
 			owned.push(bytes[pos]);
 		}

--- a/escape_string/src/lib.rs
+++ b/escape_string/src/lib.rs
@@ -150,12 +150,11 @@ pub fn escape<'a>(text: &'a str) -> Cow<'a, str> {
 	let mut owned = None;
 
 	for pos in 0..bytes.len() {
-		let special: Box<[u8]> = std::ascii::escape_default(bytes[pos]).collect();
-		if special.len() > 1 {
+		if !(bytes[pos] as char).is_ascii() {
 			if owned.is_none() {
 				owned = Some(bytes[0..pos].to_owned());
 			}
-			owned.as_mut().unwrap().push(special);
+			owned.as_mut().unwrap().expand(std::ascii::escape_default(bytes[pos]));
 		} else if let Some(owned) = owned.as_mut() {
 			owned.push(bytes[pos]);
 		}


### PR DESCRIPTION
This will escape all non-ASCII bytes, rather than just the allowlisted special characters.